### PR TITLE
Dont wait for websockify

### DIFF
--- a/jupyter_remote_qgis_proxy/utils.py
+++ b/jupyter_remote_qgis_proxy/utils.py
@@ -1,5 +1,4 @@
 import psutil
-import time
 
 from .logger import logger
 from .qgis.utils import open_qgis
@@ -12,40 +11,29 @@ def is_process_running(process_name):
     for process in psutil.process_iter():
         try:
             if process.name().lower() == process_name.lower():
-                return True
+                # Check if the process is not a zombie
+                if process.status() != psutil.STATUS_ZOMBIE:
+                    return True
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             pass
     return False
 
 
-def wait_for_condition(condition, timeout=10):
-    """
-    Waits for a condition to be true for a specified timeout.
-
-    Args:
-        condition: A callable that returns True when the condition is met.
-        timeout: The maximum time in seconds to wait (default: 10).
-
-    Returns:
-        True if the condition becomes true before the timeout, False otherwise.
-    """
-    start_time = time.time()
-    while time.time() - start_time < timeout:
-        if condition():
-            return True
-        time.sleep(0.5)
-    return False
-
-
 def start_qgis(action, url, project_name, layer_name):
-    """Starts QGIS and waits for websockify to start if necessary."""
-    logger.info("Waiting for websockify to start")
-    running = wait_for_condition(
-        condition=lambda: is_process_running(process_name="websockify"), timeout=10
-    )
-    logger.info(f"Websockify is running: {running}")
-    logger.info("Starting QGIS")
+    """Starts QGIS if necessary.
+
+    If we have an action and a URL, we will start QGIS with those parameters.
+    If not and we just want to open QGIS without opening a specific project,
+    we will check if QGIS is already running. If it is not running, we will start it.
+    If it is running, we will skip starting QGIS.
+    """
     if action and url:
+        logger.info(
+            f"Starting QGIS with action: {action}, url: {url}, project_name: {project_name}, layer_name: {layer_name}"
+        )
         open_qgis(action, url=url, project_name=project_name, layer_name=layer_name)
     elif not is_process_running("qgis"):
+        logger.info("QGIS is not running, starting QGIS")
         open_qgis()
+    else:
+        logger.info("QGIS is already running, skipping start")

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
 import os
-from subprocess import check_call
 
 from setuptools import find_packages, setup
-from setuptools.command.build_py import build_py
-from setuptools.command.sdist import sdist
 
 HERE = os.path.dirname(__file__)
 
@@ -46,21 +43,17 @@ setup(
     data_files=[
         (
             'etc/jupyter/jupyter_server_config.d',
-            [
-                'jupyter-config/jupyter_server_config.d/jupyter_remote_qgis_proxy.json'
-            ],
+            ['jupyter-config/jupyter_server_config.d/jupyter_remote_qgis_proxy.json'],
         ),
         (
             'etc/jupyter/jupyter_notebook_config.d',
-            [
-                'jupyter-config/jupyter_notebook_config.d/jupyter_remote_qgis_proxy.json'
-            ],
+            ['jupyter-config/jupyter_notebook_config.d/jupyter_remote_qgis_proxy.json'],
         ),
         (
             'etc/jupyter/jupyter_remote_qgis_proxy.d',
             [
                 'jupyter_remote_qgis_proxy/qgis/scripts/maximize.py',
-            ]
-        )
+            ],
+        ),
     ],
 )


### PR DESCRIPTION
jupyter-remote-desktop-proxy no longer uses websockify from version 3.0.0 (https://github.com/jupyterhub/jupyter-remote-desktop-proxy/blob/main/CHANGELOG.md#v300---2025-03-22). As a result, we no longer need to wait for websockify to start before starting QGIS.

Addresses #3 